### PR TITLE
Fix AVBv3 devices

### DIFF
--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -5,7 +5,8 @@ MODDIR=${0%/*}
 $SLOT=$(resetprop -n ro.boot.slot_suffix)
 if [ -d /system/addon.d ]; then
   log -t Magisk "- Adding addon.d survival script"
-  blockdev --setrw /dev/block/mapper/system$SLOT 2>/dev/null
+  blockdev --setrw /dev/block/mapper/system$SLOT 2>/dev/null || true
+  blockdev --setrw /dev/block/by-name/system$SLOT 2>/dev/null || true
   REMOUNTED=""
   if mount | grep ' /system ' | grep -q 'ro'; then
     mount -o remount,rw /system

--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -2,7 +2,7 @@
 
 MODDIR=${0%/*}
 # addon.d
-$SLOT=$(resetprop -n ro.boot.slot_suffix)
+SLOT=$(resetprop -n ro.boot.slot_suffix)
 if [ -d /system/addon.d ]; then
   log -t Magisk "- Adding addon.d survival script"
   blockdev --setrw /dev/block/mapper/system$SLOT 2>/dev/null || true


### PR DESCRIPTION
On older A/B devices (e.g. OnePlus 7 Pro on A13) there is no mapper/system_* path. by-name should be available everywhere and works fine.